### PR TITLE
chore: move check list in PR template to comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Please delete options that are not relevant.
 - [ ] This change requires a documentation update
 - [ ] This change requires a new example
 
+<!---
 All Submissions:
 
 * [ ] A corresponding issue exists
@@ -27,3 +28,4 @@ All Submissions:
 * [ ] New and existing unit tests pass locally with my changes
 * [ ] Any dependent changes have been merged and published in downstream modules
 * [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
+-->


### PR DESCRIPTION
# Description

In order to simplify PRs, the check list of the PR template is moved to a comment block to make it optional.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)