### PR TITLE
Add basic metrics for kluctl deployment controller

### DIFF
--- a/api/v1alpha1/kluctldeployment_types.go
+++ b/api/v1alpha1/kluctldeployment_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/kluctl/flux-kluctl-controller/internal/metrics"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -486,6 +487,14 @@ func SetDeployResult(k *KluctlDeployment, revision string, result *types.Command
 			k.Status.LastDeployResult.RawResult = &raw
 		}
 	}
+	numberOfChangedObjects := len(k.Status.LastDeployResult.ParseResult().ChangedObjects)
+	metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Add(float64(numberOfChangedObjects))
+	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
+	metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
+	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Add(float64(numberOfWarnings))
+	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
+	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Add(float64(numberOfErrors))
 }
 
 func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandResult, objectHash string, err error) {
@@ -510,6 +519,12 @@ func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandR
 			k.Status.LastPruneResult.RawResult = &raw
 		}
 	}
+	numberOfDeletedObjects := len(k.Status.LastDeployResult.ParseResult().DeletedObjects)
+	metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Add(float64(numberOfDeletedObjects))
+	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
+	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Add(float64(numberOfWarnings))
+	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
+	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Add(float64(numberOfErrors))
 }
 
 func SetValidateResult(k *KluctlDeployment, revision string, result *types.ValidateResult, objectHash string, err error) {
@@ -534,6 +549,12 @@ func SetValidateResult(k *KluctlDeployment, revision string, result *types.Valid
 			k.Status.LastValidateResult.RawResult = &raw
 		}
 	}
+	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
+	metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
+	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Add(float64(numberOfWarnings))
+	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
+	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Add(float64(numberOfErrors))
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/kluctldeployment_types.go
+++ b/api/v1alpha1/kluctldeployment_types.go
@@ -488,13 +488,13 @@ func SetDeployResult(k *KluctlDeployment, revision string, result *types.Command
 		}
 	}
 	numberOfChangedObjects := len(k.Status.LastDeployResult.ParseResult().ChangedObjects)
-	internal_metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Add(float64(numberOfChangedObjects))
+	internal_metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Set(float64(numberOfChangedObjects))
 	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Set(float64(numberOfOrphanObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Set(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Set(float64(numberOfErrors))
 }
 
 func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandResult, objectHash string, err error) {
@@ -520,11 +520,11 @@ func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandR
 		}
 	}
 	numberOfDeletedObjects := len(k.Status.LastDeployResult.ParseResult().DeletedObjects)
-	internal_metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Add(float64(numberOfDeletedObjects))
+	internal_metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Set(float64(numberOfDeletedObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Set(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Set(float64(numberOfErrors))
 }
 
 func SetValidateResult(k *KluctlDeployment, revision string, result *types.ValidateResult, objectHash string, err error) {
@@ -550,11 +550,11 @@ func SetValidateResult(k *KluctlDeployment, revision string, result *types.Valid
 		}
 	}
 	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Set(float64(numberOfOrphanObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Set(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Set(float64(numberOfErrors))
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/kluctldeployment_types.go
+++ b/api/v1alpha1/kluctldeployment_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/fluxcd/pkg/apis/meta"
-	internal_metrics "github.com/kluctl/flux-kluctl-controller/internal/metrics"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -487,14 +486,6 @@ func SetDeployResult(k *KluctlDeployment, revision string, result *types.Command
 			k.Status.LastDeployResult.RawResult = &raw
 		}
 	}
-	numberOfChangedObjects := len(k.Status.LastDeployResult.ParseResult().ChangedObjects)
-	internal_metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Set(float64(numberOfChangedObjects))
-	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Set(float64(numberOfOrphanObjects))
-	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Set(float64(numberOfWarnings))
-	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Set(float64(numberOfErrors))
 }
 
 func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandResult, objectHash string, err error) {
@@ -519,12 +510,6 @@ func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandR
 			k.Status.LastPruneResult.RawResult = &raw
 		}
 	}
-	numberOfDeletedObjects := len(k.Status.LastDeployResult.ParseResult().DeletedObjects)
-	internal_metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Set(float64(numberOfDeletedObjects))
-	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Set(float64(numberOfWarnings))
-	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Set(float64(numberOfErrors))
 }
 
 func SetValidateResult(k *KluctlDeployment, revision string, result *types.ValidateResult, objectHash string, err error) {
@@ -549,12 +534,6 @@ func SetValidateResult(k *KluctlDeployment, revision string, result *types.Valid
 			k.Status.LastValidateResult.RawResult = &raw
 		}
 	}
-	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Set(float64(numberOfOrphanObjects))
-	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Set(float64(numberOfWarnings))
-	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Set(float64(numberOfErrors))
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/kluctldeployment_types.go
+++ b/api/v1alpha1/kluctldeployment_types.go
@@ -18,7 +18,7 @@ package v1alpha1
 
 import (
 	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/kluctl/flux-kluctl-controller/internal/metrics"
+	internal_metrics "github.com/kluctl/flux-kluctl-controller/internal/metrics"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -488,13 +488,13 @@ func SetDeployResult(k *KluctlDeployment, revision string, result *types.Command
 		}
 	}
 	numberOfChangedObjects := len(k.Status.LastDeployResult.ParseResult().ChangedObjects)
-	metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Add(float64(numberOfChangedObjects))
+	internal_metrics.NewKluctlNumberOfChanges(k.Namespace, k.Name).Add(float64(numberOfChangedObjects))
 	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "deploy").Add(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "deploy").Add(float64(numberOfErrors))
 }
 
 func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandResult, objectHash string, err error) {
@@ -520,11 +520,11 @@ func SetPruneResult(k *KluctlDeployment, revision string, result *types.CommandR
 		}
 	}
 	numberOfDeletedObjects := len(k.Status.LastDeployResult.ParseResult().DeletedObjects)
-	metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Add(float64(numberOfDeletedObjects))
+	internal_metrics.NewKluctlNumberOfDeletedObjects(k.Namespace, k.Name).Add(float64(numberOfDeletedObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "prune").Add(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "prune").Add(float64(numberOfErrors))
 }
 
 func SetValidateResult(k *KluctlDeployment, revision string, result *types.ValidateResult, objectHash string, err error) {
@@ -550,11 +550,11 @@ func SetValidateResult(k *KluctlDeployment, revision string, result *types.Valid
 		}
 	}
 	numberOfOrphanObjects := len(k.Status.LastDeployResult.ParseResult().OrphanObjects)
-	metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
+	internal_metrics.NewKluctlNumberOfOrphanObjects(k.Namespace, k.Name).Add(float64(numberOfOrphanObjects))
 	numberOfWarnings := len(k.Status.LastDeployResult.ParseResult().Warnings)
-	metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Add(float64(numberOfWarnings))
+	internal_metrics.NewKluctlNumberOfWarnings(k.Namespace, k.Name, "validate").Add(float64(numberOfWarnings))
 	numberOfErrors := len(k.Status.LastDeployResult.ParseResult().Errors)
-	metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Add(float64(numberOfErrors))
+	internal_metrics.NewKluctlNumberOfErrors(k.Namespace, k.Name, "validate").Add(float64(numberOfErrors))
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/kluctl_project.go
+++ b/controllers/kluctl_project.go
@@ -752,7 +752,7 @@ func (pt *preparedTarget) kluctlDeploy(ctx context.Context, targetContext *kluct
 
 	cmdResult, err := cmd.Run(ctx, targetContext.SharedContext.K, nil)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "deploy")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Add(float64(len(cmdResult.SeenImages)))
+	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 
@@ -763,7 +763,7 @@ func (pt *preparedTarget) kluctlPokeImages(ctx context.Context, targetContext *k
 
 	cmdResult, err := cmd.Run(ctx, targetContext.SharedContext.K)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "poke-images")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Add(float64(len(cmdResult.SeenImages)))
+	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 
@@ -777,7 +777,7 @@ func (pt *preparedTarget) kluctlPrune(ctx context.Context, targetContext *kluctl
 	}
 	cmdResult, err := pt.doDeleteObjects(ctx, targetContext.SharedContext.K, refs)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "prune")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Add(float64(len(cmdResult.SeenImages)))
+	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 

--- a/controllers/kluctl_project.go
+++ b/controllers/kluctl_project.go
@@ -752,7 +752,6 @@ func (pt *preparedTarget) kluctlDeploy(ctx context.Context, targetContext *kluct
 
 	cmdResult, err := cmd.Run(ctx, targetContext.SharedContext.K, nil)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "deploy")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 
@@ -763,7 +762,6 @@ func (pt *preparedTarget) kluctlPokeImages(ctx context.Context, targetContext *k
 
 	cmdResult, err := cmd.Run(ctx, targetContext.SharedContext.K)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "poke-images")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 
@@ -777,7 +775,6 @@ func (pt *preparedTarget) kluctlPrune(ctx context.Context, targetContext *kluctl
 	}
 	cmdResult, err := pt.doDeleteObjects(ctx, targetContext.SharedContext.K, refs)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "prune")
-	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(len(cmdResult.SeenImages)))
 	return cmdResult, err
 }
 
@@ -844,4 +841,6 @@ func (pt *preparedTarget) exportCommandResultMetricsToProm(cmdResult *types2.Com
 	internal_metrics.NewKluctlNumberOfWarnings(pt.pp.obj.Namespace, pt.pp.obj.Name, commandName).Set(float64(numberOfWarnings))
 	numberOfErrors := len(cmdResult.Errors)
 	internal_metrics.NewKluctlNumberOfErrors(pt.pp.obj.Namespace, pt.pp.obj.Name, commandName).Set(float64(numberOfErrors))
+	numberOfImages := len(cmdResult.SeenImages)
+	internal_metrics.NewKluctlNumberOfImages(pt.pp.obj.Namespace, pt.pp.obj.Name).Set(float64(numberOfImages))
 }

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -296,6 +296,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 		}
 
 		if needPrune {
+			timer := prometheus.NewTimer(metrics2.NewKluctlPruneDuration(obj.ObjectMeta.Namespace, obj.ObjectMeta.Name))
 			// run garbage collection for stale objects that do not have pruning disabled
 			pruneResult, err := pt.kluctlPrune(ctx, targetContext)
 			kluctlv1.SetPruneResult(obj, pp.sourceRevision, pruneResult, objectsHash, err)
@@ -303,6 +304,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 				setReadinessWithRevision(obj, metav1.ConditionFalse, kluctlv1.PruneFailedReason, err.Error(), pp.sourceRevision)
 				return nil
 			}
+			timer.ObserveDuration()
 			numberOfSeenImages = len(pruneResult.SeenImages)
 		}
 

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -276,6 +276,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 		if needDeploy {
 			// deploy the kluctl project
 			var deployResult *types.CommandResult
+			timer := prometheus.NewTimer(metrics2.NewKluctlDeploymentDuration(obj.ObjectMeta.Namespace, obj.ObjectMeta.Name, obj.Spec.DeployMode))
 			if obj.Spec.DeployMode == kluctlv1.KluctlDeployModeFull {
 				deployResult, err = pt.kluctlDeploy(ctx, targetContext)
 			} else if obj.Spec.DeployMode == kluctlv1.KluctlDeployPokeImages {
@@ -290,6 +291,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 				setReadinessWithRevision(obj, metav1.ConditionFalse, kluctlv1.DeployFailedReason, err.Error(), pp.sourceRevision)
 				return nil
 			}
+			timer.ObserveDuration()
 			numberOfSeenImages = len(deployResult.SeenImages)
 		}
 

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -340,10 +340,11 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 	finalStatus, reason := r.buildFinalStatus(obj)
 	if reason != kluctlv1.ReconciliationSucceededReason {
 		setReadinessWithRevision(obj, metav1.ConditionFalse, reason, finalStatus, pp.sourceRevision)
+		metrics2.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(0.0))
 		return &ctrlResult, pp.sourceRevision, fmt.Errorf(finalStatus)
 	}
 	setReadinessWithRevision(obj, metav1.ConditionTrue, reason, finalStatus, pp.sourceRevision)
-
+	metrics2.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(1.0)
 	return &ctrlResult, pp.sourceRevision, nil
 }
 

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -329,11 +329,11 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 	finalStatus, reason := r.buildFinalStatus(obj)
 	if reason != kluctlv1.ReconciliationSucceededReason {
 		setReadinessWithRevision(obj, metav1.ConditionFalse, reason, finalStatus, pp.sourceRevision)
-		internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(0.0)
+		internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Set(0.0)
 		return &ctrlResult, pp.sourceRevision, fmt.Errorf(finalStatus)
 	}
 	setReadinessWithRevision(obj, metav1.ConditionTrue, reason, finalStatus, pp.sourceRevision)
-	internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(1.0)
+	internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Set(1.0)
 	return &ctrlResult, pp.sourceRevision, nil
 }
 
@@ -563,8 +563,8 @@ func (r *KluctlDeploymentReconciler) exportDeploymentObjectToProm(obj *kluctlv1.
 	}
 
 	//Export as Prometheus metric
-	internal_metrics.NewKluctlPruneEnabled(obj.Namespace, obj.Name).Add(pruneEnabled)
-	internal_metrics.NewKluctlDryRunEnabled(obj.Namespace, obj.Name).Add(dryRunEnabled)
-	internal_metrics.NewKluctlDeploymentInterval(obj.Namespace, obj.Name).Add(deploymentInterval)
-	internal_metrics.NewKluctlSourceSpec(obj.Namespace, obj.Name, obj.Spec.Source.URL, obj.Spec.Source.Path, obj.Spec.Source.Ref.String()).Add(0.0)
+	internal_metrics.NewKluctlPruneEnabled(obj.Namespace, obj.Name).Set(pruneEnabled)
+	internal_metrics.NewKluctlDryRunEnabled(obj.Namespace, obj.Name).Set(dryRunEnabled)
+	internal_metrics.NewKluctlDeploymentInterval(obj.Namespace, obj.Name).Set(deploymentInterval)
+	internal_metrics.NewKluctlSourceSpec(obj.Namespace, obj.Name, obj.Spec.Source.URL, obj.Spec.Source.Path, obj.Spec.Source.Ref.String()).Set(0.0)
 }

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -553,8 +553,12 @@ func (r *KluctlDeploymentReconciler) exportDeploymentObjectToProm(obj *kluctlv1.
 	if obj.Spec.DryRun {
 		dryRunEnabled = 1.0
 	}
+	//If not set, it defaults to interval
+	if obj.Spec.DeployInterval == nil {
+		deploymentInterval = obj.Spec.Interval.Seconds()
+	}
 	//Deployment interval of never defaults to zero
-	if !obj.Spec.DeployInterval.Never {
+	if obj.Spec.DeployInterval != nil && !obj.Spec.DeployInterval.Never {
 		deploymentInterval = obj.Spec.DeployInterval.Duration.Seconds()
 	}
 

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/hashicorp/go-retryablehttp"
 	kluctlv1 "github.com/kluctl/flux-kluctl-controller/api/v1alpha1"
-	metrics2 "github.com/kluctl/flux-kluctl-controller/internal/metrics"
+	internal_metrics "github.com/kluctl/flux-kluctl-controller/internal/metrics"
 	ssh_pool "github.com/kluctl/kluctl/v2/pkg/git/ssh-pool"
 	"github.com/kluctl/kluctl/v2/pkg/kluctl_project"
 	project "github.com/kluctl/kluctl/v2/pkg/kluctl_project"
@@ -329,11 +329,11 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 	finalStatus, reason := r.buildFinalStatus(obj)
 	if reason != kluctlv1.ReconciliationSucceededReason {
 		setReadinessWithRevision(obj, metav1.ConditionFalse, reason, finalStatus, pp.sourceRevision)
-		metrics2.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(0.0))
+		internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(0.0)
 		return &ctrlResult, pp.sourceRevision, fmt.Errorf(finalStatus)
 	}
 	setReadinessWithRevision(obj, metav1.ConditionTrue, reason, finalStatus, pp.sourceRevision)
-	metrics2.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(1.0)
+	internal_metrics.NewKluctlLastObjectStatus(obj.Namespace, obj.Name).Add(1.0)
 	return &ctrlResult, pp.sourceRevision, nil
 }
 
@@ -559,8 +559,8 @@ func (r *KluctlDeploymentReconciler) exportDeploymentObjectToProm(obj *kluctlv1.
 	}
 
 	//Export as Prometheus metric
-	metrics2.NewKluctlPruneEnabled(obj.Namespace, obj.Name).Add(pruneEnabled)
-	metrics2.NewKluctlDryRunEnabled(obj.Namespace, obj.Name).Add(dryRunEnabled)
-	metrics2.NewKluctlDeploymentInterval(obj.Namespace, obj.Name).Add(deploymentInterval)
-	metrics2.NewKluctlSourceSpec(obj.Namespace, obj.Name, obj.Spec.Source.URL, obj.Spec.Source.Path, obj.Spec.Source.Ref.String()).Add(0.0)
+	internal_metrics.NewKluctlPruneEnabled(obj.Namespace, obj.Name).Add(pruneEnabled)
+	internal_metrics.NewKluctlDryRunEnabled(obj.Namespace, obj.Name).Add(dryRunEnabled)
+	internal_metrics.NewKluctlDeploymentInterval(obj.Namespace, obj.Name).Add(deploymentInterval)
+	internal_metrics.NewKluctlSourceSpec(obj.Namespace, obj.Name, obj.Spec.Source.URL, obj.Spec.Source.Path, obj.Spec.Source.Ref.String()).Add(0.0)
 }

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -309,12 +309,14 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 		}
 
 		if needValidate {
+			timer := prometheus.NewTimer(metrics2.NewKluctlValidateDuration(obj.ObjectMeta.Namespace, obj.ObjectMeta.Name))
 			validateResult, err := pt.kluctlValidate(ctx, targetContext)
 			kluctlv1.SetValidateResult(obj, pp.sourceRevision, validateResult, objectsHash, err)
 			if err != nil {
 				setReadinessWithRevision(obj, metav1.ConditionFalse, kluctlv1.ValidateFailedReason, err.Error(), pp.sourceRevision)
 				return nil
 			}
+			timer.ObserveDuration()
 		}
 		metrics2.NewKluctlNumberOfImages(obj.Namespace, obj.Name).Add(float64(numberOfSeenImages))
 		return nil

--- a/controllers/kluctldeployment_controller.go
+++ b/controllers/kluctldeployment_controller.go
@@ -231,7 +231,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 		obj.Status.SetRawTarget(targetContext.Target)
 
 		objectsHash := r.calcObjectsHash(targetContext)
-
+		numberOfSeenImages := 0
 		needDeploy := false
 		needPrune := false
 		needValidate := false
@@ -290,6 +290,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 				setReadinessWithRevision(obj, metav1.ConditionFalse, kluctlv1.DeployFailedReason, err.Error(), pp.sourceRevision)
 				return nil
 			}
+			numberOfSeenImages = len(deployResult.SeenImages)
 		}
 
 		if needPrune {
@@ -300,6 +301,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 				setReadinessWithRevision(obj, metav1.ConditionFalse, kluctlv1.PruneFailedReason, err.Error(), pp.sourceRevision)
 				return nil
 			}
+			numberOfSeenImages = len(pruneResult.SeenImages)
 		}
 
 		if needValidate {
@@ -310,7 +312,7 @@ func (r *KluctlDeploymentReconciler) doReconcile(
 				return nil
 			}
 		}
-
+		metrics2.NewKluctlNumberOfImages(obj.Namespace, obj.Name).Add(float64(numberOfSeenImages))
 		return nil
 	})
 	obj.Status.ObservedGeneration = obj.GetGeneration()

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,0 +1,9 @@
+<!-- This comment is uncommented when auto-synced to www-kluctl.io
+
+---
+title: Metrics
+linkTitle: Metrics
+description: OpenMetrics-compatible export of controller metrics
+weight: 10
+---
+-->

--- a/docs/metrics/v1alpha1/README.md
+++ b/docs/metrics/v1alpha1/README.md
@@ -1,0 +1,15 @@
+<!-- This comment is uncommented when auto-synced to www-kluctl.io
+
+---
+title: v1alpha1 metrics
+linkTitle: v1alpha1 metrics
+description: flux.kluctl.io/v1alpha1 metrics
+weight: 10
+---
+-->
+
+# Prometheus Metrics
+
+The controller exports several metrics in the [OpenMetrics compatible format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md). They can be scraped by all sorts of monitoring solutions (e.g. Prometheus) or stored in a database. Because the controller is based on [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime), all the [default metrics](https://book.kubebuilder.io/reference/metrics-reference.html) as well as the following controller-specific custom metrics are exported:
+
+- [kluctldeployment_controller](kluctldeployment_controller.md)

--- a/docs/metrics/v1alpha1/README.md
+++ b/docs/metrics/v1alpha1/README.md
@@ -13,3 +13,4 @@ weight: 10
 The controller exports several metrics in the [OpenMetrics compatible format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md). They can be scraped by all sorts of monitoring solutions (e.g. Prometheus) or stored in a database. Because the controller is based on [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime), all the [default metrics](https://book.kubebuilder.io/reference/metrics-reference.html) as well as the following controller-specific custom metrics are exported:
 
 - [kluctldeployment_controller](kluctldeployment_controller.md)
+- [kluctl_project](kluctl_project.md)

--- a/docs/metrics/v1alpha1/kluctl_project.md
+++ b/docs/metrics/v1alpha1/kluctl_project.md
@@ -1,0 +1,23 @@
+<!-- This comment is uncommented when auto-synced to www-kluctl.io
+
+---
+title: Metrics of the KluctlProject
+linkTitle: KluctlProject Metrics
+description: KluctlProject documentation
+weight: 20
+---
+-->
+
+# Exported Metrics References
+
+| Metrics name                | Type      | Description                                                                           |
+|-----------------------------|-----------|---------------------------------------------------------------------------------------|
+| deployment_duration_seconds | Histogram | How long a single deployment takes in seconds.                                        |
+| number_of_changes           | Gauge     | How many things has been changed by a single deployment.                              |
+| number_of_deleted_objects   | Gauge     | How many things has been deleted by a single deployment.                              |
+| number_of_errors            | Gauge     | How many errors are related to a single deployment.                                   |
+| number_of_images            | Gauge     | Number of images of a single deployment.                                              |
+| number_of_orphan_objects    | Gauge     | How many orphans are related to a single deployment.                                  |
+| number_of_warnings          | Gauge     | How many warnings are related to a single deployment.                                 |
+| prune_duration_seconds      | Histogram | How long a single prune takes in seconds.                                             |
+| validate_duration_seconds   | Histogram | How long a single validate takes in seconds.                                          |

--- a/docs/metrics/v1alpha1/kluctldeployment_controller.md
+++ b/docs/metrics/v1alpha1/kluctldeployment_controller.md
@@ -1,0 +1,28 @@
+<!-- This comment is uncommented when auto-synced to www-kluctl.io
+
+---
+title: Metrics of the KluctlDeployment Controller
+linkTitle: KluctlDeployment Controller Metrics
+description: KluctlDeployment documentation
+weight: 20
+---
+-->
+
+# Exported Metrics References
+
+| Metrics name                | Type      | Description                                                                           |
+|-----------------------------|-----------|---------------------------------------------------------------------------------------|
+| deployment_duration_seconds | Histogram | How long a single deployment takes in seconds.                                        |
+| deployment_interval_seconds | Gauge     | The configured deployment interval of a single deployment.                            |
+| dry_run_enabled             | Gauge     | Is dry-run enabled for a single deployment.                                           |
+| last_object_status          | Gauge     | Last object status of a single deployment. Zero means failure and one means success.  |
+| number_of_changes           | Gauge     | How many things has been changed by a single deployment.                              |
+| number_of_deleted_objects   | Gauge     | How many things has been deleted by a single deployment.                              |
+| number_of_errors            | Gauge     | How many errors are related to a single deployment.                                   |
+| number_of_images            | Gauge     | Number of images of a single deployment.                                              |
+| number_of_orphan_objects    | Gauge     | How many orphans are related to a single deployment.                                  |
+| number_of_warnings          | Gauge     | How many warnings are related to a single deployment.                                 |
+| prune_duration_seconds      | Histogram | How long a single prune takes in seconds.                                             |
+| prune_enabled               | Gauge     | Is pruning enabled for a single deployment.                                           |
+| source_spec                 | Gauge     | The configured source spec of a single deployment exported via labels.                |
+| validate_duration_seconds   | Histogram | How long a single validate takes in seconds.                                          |

--- a/docs/metrics/v1alpha1/kluctldeployment_controller.md
+++ b/docs/metrics/v1alpha1/kluctldeployment_controller.md
@@ -12,17 +12,8 @@ weight: 20
 
 | Metrics name                | Type      | Description                                                                           |
 |-----------------------------|-----------|---------------------------------------------------------------------------------------|
-| deployment_duration_seconds | Histogram | How long a single deployment takes in seconds.                                        |
 | deployment_interval_seconds | Gauge     | The configured deployment interval of a single deployment.                            |
 | dry_run_enabled             | Gauge     | Is dry-run enabled for a single deployment.                                           |
 | last_object_status          | Gauge     | Last object status of a single deployment. Zero means failure and one means success.  |
-| number_of_changes           | Gauge     | How many things has been changed by a single deployment.                              |
-| number_of_deleted_objects   | Gauge     | How many things has been deleted by a single deployment.                              |
-| number_of_errors            | Gauge     | How many errors are related to a single deployment.                                   |
-| number_of_images            | Gauge     | Number of images of a single deployment.                                              |
-| number_of_orphan_objects    | Gauge     | How many orphans are related to a single deployment.                                  |
-| number_of_warnings          | Gauge     | How many warnings are related to a single deployment.                                 |
-| prune_duration_seconds      | Histogram | How long a single prune takes in seconds.                                             |
 | prune_enabled               | Gauge     | Is pruning enabled for a single deployment.                                           |
 | source_spec                 | Gauge     | The configured source spec of a single deployment exported via labels.                |
-| validate_duration_seconds   | Histogram | How long a single validate takes in seconds.                                          |

--- a/internal/metrics/kluctl_project.go
+++ b/internal/metrics/kluctl_project.go
@@ -1,0 +1,124 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	KluctlProjectControllerSubsystem = "kluctlprojects"
+
+	DeploymentDurationKey     = "deployment_duration_seconds"
+	NumberOfChangesKey        = "number_of_changes"
+	NumberOfDeletedObjectsKey = "number_of_deleted_objects"
+	NumberOfErrorsKey         = "number_of_errors"
+	NumberOfImagesKey         = "number_of_images"
+	NumberOfOrphanObjectsKey  = "number_of_orphan_objects"
+	NumberOfWarningsKey       = "number_of_warnings"
+	PruneDurationKey          = "prune_duration_seconds"
+	ValidateDurationKey       = "validate_duration_seconds"
+)
+
+var (
+	deploymentDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      DeploymentDurationKey,
+		Help:      "How long a single deployment takes in seconds.",
+	}, []string{"namespace", "name", "mode"})
+
+	numberOfChanges = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlProjectControllerSubsystem,
+		Name:      NumberOfChangesKey,
+		Help:      "How many things has been changed by a single project.",
+	}, []string{"namespace", "name"})
+
+	numberOfDeletedObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlProjectControllerSubsystem,
+		Name:      NumberOfDeletedObjectsKey,
+		Help:      "How many things has been deleted by a single project.",
+	}, []string{"namespace", "name"})
+
+	numberOfErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlProjectControllerSubsystem,
+		Name:      NumberOfErrorsKey,
+		Help:      "How many errors are related to a single project.",
+	}, []string{"namespace", "name", "action"})
+
+	numberOfImages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfImagesKey,
+		Help:      "Number of images of a single project.",
+	}, []string{"namespace", "name"})
+
+	numberOfOrphanObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlProjectControllerSubsystem,
+		Name:      NumberOfOrphanObjectsKey,
+		Help:      "How many orphans are related to a single project.",
+	}, []string{"namespace", "name"})
+
+	numberOfWarnings = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlProjectControllerSubsystem,
+		Name:      NumberOfWarningsKey,
+		Help:      "How many warnings are related to a single project.",
+	}, []string{"namespace", "name", "action"})
+
+	pruneDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      PruneDurationKey,
+		Help:      "How long a single prune takes in seconds.",
+	}, []string{"namespace", "name"})
+
+	validateDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      ValidateDurationKey,
+		Help:      "How long a single validate takes in seconds.",
+	}, []string{"namespace", "name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(deploymentDuration)
+	metrics.Registry.MustRegister(numberOfChanges)
+	metrics.Registry.MustRegister(numberOfDeletedObjects)
+	metrics.Registry.MustRegister(numberOfErrors)
+	metrics.Registry.MustRegister(numberOfImages)
+	metrics.Registry.MustRegister(numberOfOrphanObjects)
+	metrics.Registry.MustRegister(numberOfWarnings)
+	metrics.Registry.MustRegister(pruneDuration)
+	metrics.Registry.MustRegister(validateDuration)
+}
+
+func NewKluctlDeploymentDuration(namespace string, name string, mode string) prometheus.Observer {
+	return deploymentDuration.WithLabelValues(namespace, name, mode)
+}
+
+func NewKluctlNumberOfChanges(namespace string, name string) prometheus.Gauge {
+	return numberOfChanges.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfDeletedObjects(namespace string, name string) prometheus.Gauge {
+	return numberOfDeletedObjects.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfErrors(namespace string, name string, action string) prometheus.Gauge {
+	return numberOfErrors.WithLabelValues(namespace, name, action)
+}
+
+func NewKluctlNumberOfImages(namespace string, name string) prometheus.Gauge {
+	return numberOfImages.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfOrphanObjects(namespace string, name string) prometheus.Gauge {
+	return numberOfOrphanObjects.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfWarnings(namespace string, name string, action string) prometheus.Gauge {
+	return numberOfWarnings.WithLabelValues(namespace, name, action)
+}
+
+func NewKluctlPruneDuration(namespace string, name string) prometheus.Observer {
+	return pruneDuration.WithLabelValues(namespace, name)
+}
+
+func NewKluctlValidateDuration(namespace string, name string) prometheus.Observer {
+	return validateDuration.WithLabelValues(namespace, name)
+}

--- a/internal/metrics/kluctldeployment_controller.go
+++ b/internal/metrics/kluctldeployment_controller.go
@@ -1,0 +1,185 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metrics subsystem and all keys used by the kluctldeployment controller.
+const (
+	KluctlDeploymentControllerSubsystem = "kluctldeployments"
+
+	DeploymentDurationKey     = "deployment_duration_seconds"
+	DeploymentIntervalKey     = "deployment_interval_seconds"
+	DryRunEnabledKey          = "dry_run_enabled"
+	LastObjectStatusKey       = "last_object_status"
+	NumberOfChangesKey        = "number_of_changes"
+	NumberOfDeletedObjectsKey = "number_of_deleted_objects"
+	NumberOfErrorsKey         = "number_of_errors"
+	NumberOfImagesKey         = "number_of_images"
+	NumberOfOrphanObjectsKey  = "number_of_orphan_objects"
+	NumberOfWarningsKey       = "number_of_warnings"
+	PruneDurationKey          = "prune_duration_seconds"
+	PruneEnabledKey           = "prune_enabled"
+	SourceSpecKey             = "source_spec"
+	ValidateDurationKey       = "validate_duration_seconds"
+)
+
+var (
+	deploymentDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      DeploymentDurationKey,
+		Help:      "How long a single deployment takes in seconds.",
+	}, []string{"namespace", "name", "mode"})
+
+	deploymentInterval = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      DeploymentIntervalKey,
+		Help:      "The configured deployment interval of a single deployment.",
+	}, []string{"namespace", "name"})
+
+	dryRunEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      DryRunEnabledKey,
+		Help:      "Is dry-run enabled for a single deployment.",
+	}, []string{"namespace", "name"})
+
+	lastObjectStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      LastObjectStatusKey,
+		Help:      "Last object status of a single deployment.",
+	}, []string{"namespace", "name"})
+
+	numberOfChanges = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfChangesKey,
+		Help:      "How many things has been changed by a single deployment.",
+	}, []string{"namespace", "name"})
+
+	numberOfDeletedObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfDeletedObjectsKey,
+		Help:      "How many things has been deleted by a single deployment.",
+	}, []string{"namespace", "name"})
+
+	numberOfErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfErrorsKey,
+		Help:      "How many errors are related to a single deployment.",
+	}, []string{"namespace", "name", "action"})
+
+	numberOfImages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfImagesKey,
+		Help:      "Number of images of a single deployment.",
+	}, []string{"namespace", "name"})
+
+	numberOfOrphanObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfOrphanObjectsKey,
+		Help:      "How many orphans are related to a single deployment.",
+	}, []string{"namespace", "name"})
+
+	numberOfWarnings = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      NumberOfWarningsKey,
+		Help:      "How many warnings are related to a single deployment.",
+	}, []string{"namespace", "name", "action"})
+
+	pruneDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      PruneDurationKey,
+		Help:      "How long a single prune takes in seconds.",
+	}, []string{"namespace", "name"})
+
+	pruneEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      PruneEnabledKey,
+		Help:      "Is pruning enabled for a single deployment.",
+	}, []string{"namespace", "name"})
+
+	sourceSpec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      SourceSpecKey,
+		Help:      "The configured source spec of a single deployment.",
+	}, []string{"namespace", "name", "url", "path", "ref"})
+
+	validateDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KluctlDeploymentControllerSubsystem,
+		Name:      ValidateDurationKey,
+		Help:      "How long a single validate takes in seconds.",
+	}, []string{"namespace", "name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(deploymentDuration)
+	metrics.Registry.MustRegister(deploymentInterval)
+	metrics.Registry.MustRegister(dryRunEnabled)
+	metrics.Registry.MustRegister(lastObjectStatus)
+	metrics.Registry.MustRegister(numberOfChanges)
+	metrics.Registry.MustRegister(numberOfDeletedObjects)
+	metrics.Registry.MustRegister(numberOfErrors)
+	metrics.Registry.MustRegister(numberOfImages)
+	metrics.Registry.MustRegister(numberOfOrphanObjects)
+	metrics.Registry.MustRegister(numberOfWarnings)
+	metrics.Registry.MustRegister(pruneDuration)
+	metrics.Registry.MustRegister(pruneEnabled)
+	metrics.Registry.MustRegister(sourceSpec)
+	metrics.Registry.MustRegister(validateDuration)
+}
+
+func NewKluctlDeploymentDuration(namespace string, name string, mode string) prometheus.Observer {
+	return deploymentDuration.WithLabelValues(namespace, name, mode)
+}
+
+func NewKluctlDeploymentInterval(namespace string, name string) prometheus.Gauge {
+	return dryRunEnabled.WithLabelValues(namespace, name)
+}
+
+func NewKluctlDryRunEnabled(namespace string, name string) prometheus.Gauge {
+	return dryRunEnabled.WithLabelValues(namespace, name)
+}
+
+func NewKluctlLastObjectStatus(namespace string, name string) prometheus.Gauge {
+	return lastObjectStatus.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfChanges(namespace string, name string) prometheus.Gauge {
+	return numberOfChanges.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfDeletedObjects(namespace string, name string) prometheus.Gauge {
+	return numberOfDeletedObjects.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfErrors(namespace string, name string, action string) prometheus.Gauge {
+	return numberOfErrors.WithLabelValues(namespace, name, action)
+}
+
+func NewKluctlNumberOfImages(namespace string, name string) prometheus.Gauge {
+	return numberOfImages.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfOrphanObjects(namespace string, name string) prometheus.Gauge {
+	return numberOfOrphanObjects.WithLabelValues(namespace, name)
+}
+
+func NewKluctlNumberOfWarnings(namespace string, name string, action string) prometheus.Gauge {
+	return numberOfWarnings.WithLabelValues(namespace, name, action)
+}
+
+func NewKluctlPruneDuration(namespace string, name string) prometheus.Observer {
+	return pruneDuration.WithLabelValues(namespace, name)
+}
+
+func NewKluctlPruneEnabled(namespace string, name string) prometheus.Gauge {
+	return pruneEnabled.WithLabelValues(namespace, name)
+}
+
+func NewKluctlSourceSpec(namespace string, name string, url string, path string, ref string) prometheus.Gauge {
+	return sourceSpec.WithLabelValues(namespace, name, url, path, ref)
+}
+
+func NewKluctlValidateDuration(namespace string, name string) prometheus.Observer {
+	return validateDuration.WithLabelValues(namespace, name)
+}

--- a/internal/metrics/kluctldeployment_controller.go
+++ b/internal/metrics/kluctldeployment_controller.go
@@ -9,29 +9,14 @@ import (
 const (
 	KluctlDeploymentControllerSubsystem = "kluctldeployments"
 
-	DeploymentDurationKey     = "deployment_duration_seconds"
-	DeploymentIntervalKey     = "deployment_interval_seconds"
-	DryRunEnabledKey          = "dry_run_enabled"
-	LastObjectStatusKey       = "last_object_status"
-	NumberOfChangesKey        = "number_of_changes"
-	NumberOfDeletedObjectsKey = "number_of_deleted_objects"
-	NumberOfErrorsKey         = "number_of_errors"
-	NumberOfImagesKey         = "number_of_images"
-	NumberOfOrphanObjectsKey  = "number_of_orphan_objects"
-	NumberOfWarningsKey       = "number_of_warnings"
-	PruneDurationKey          = "prune_duration_seconds"
-	PruneEnabledKey           = "prune_enabled"
-	SourceSpecKey             = "source_spec"
-	ValidateDurationKey       = "validate_duration_seconds"
+	DeploymentIntervalKey = "deployment_interval_seconds"
+	DryRunEnabledKey      = "dry_run_enabled"
+	LastObjectStatusKey   = "last_object_status"
+	PruneEnabledKey       = "prune_enabled"
+	SourceSpecKey         = "source_spec"
 )
 
 var (
-	deploymentDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      DeploymentDurationKey,
-		Help:      "How long a single deployment takes in seconds.",
-	}, []string{"namespace", "name", "mode"})
-
 	deploymentInterval = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KluctlDeploymentControllerSubsystem,
 		Name:      DeploymentIntervalKey,
@@ -50,48 +35,6 @@ var (
 		Help:      "Last object status of a single deployment.",
 	}, []string{"namespace", "name"})
 
-	numberOfChanges = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfChangesKey,
-		Help:      "How many things has been changed by a single deployment.",
-	}, []string{"namespace", "name"})
-
-	numberOfDeletedObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfDeletedObjectsKey,
-		Help:      "How many things has been deleted by a single deployment.",
-	}, []string{"namespace", "name"})
-
-	numberOfErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfErrorsKey,
-		Help:      "How many errors are related to a single deployment.",
-	}, []string{"namespace", "name", "action"})
-
-	numberOfImages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfImagesKey,
-		Help:      "Number of images of a single deployment.",
-	}, []string{"namespace", "name"})
-
-	numberOfOrphanObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfOrphanObjectsKey,
-		Help:      "How many orphans are related to a single deployment.",
-	}, []string{"namespace", "name"})
-
-	numberOfWarnings = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      NumberOfWarningsKey,
-		Help:      "How many warnings are related to a single deployment.",
-	}, []string{"namespace", "name", "action"})
-
-	pruneDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      PruneDurationKey,
-		Help:      "How long a single prune takes in seconds.",
-	}, []string{"namespace", "name"})
-
 	pruneEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KluctlDeploymentControllerSubsystem,
 		Name:      PruneEnabledKey,
@@ -103,33 +46,14 @@ var (
 		Name:      SourceSpecKey,
 		Help:      "The configured source spec of a single deployment.",
 	}, []string{"namespace", "name", "url", "path", "ref"})
-
-	validateDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem: KluctlDeploymentControllerSubsystem,
-		Name:      ValidateDurationKey,
-		Help:      "How long a single validate takes in seconds.",
-	}, []string{"namespace", "name"})
 )
 
 func init() {
-	metrics.Registry.MustRegister(deploymentDuration)
 	metrics.Registry.MustRegister(deploymentInterval)
 	metrics.Registry.MustRegister(dryRunEnabled)
 	metrics.Registry.MustRegister(lastObjectStatus)
-	metrics.Registry.MustRegister(numberOfChanges)
-	metrics.Registry.MustRegister(numberOfDeletedObjects)
-	metrics.Registry.MustRegister(numberOfErrors)
-	metrics.Registry.MustRegister(numberOfImages)
-	metrics.Registry.MustRegister(numberOfOrphanObjects)
-	metrics.Registry.MustRegister(numberOfWarnings)
-	metrics.Registry.MustRegister(pruneDuration)
 	metrics.Registry.MustRegister(pruneEnabled)
 	metrics.Registry.MustRegister(sourceSpec)
-	metrics.Registry.MustRegister(validateDuration)
-}
-
-func NewKluctlDeploymentDuration(namespace string, name string, mode string) prometheus.Observer {
-	return deploymentDuration.WithLabelValues(namespace, name, mode)
 }
 
 func NewKluctlDeploymentInterval(namespace string, name string) prometheus.Gauge {
@@ -144,42 +68,10 @@ func NewKluctlLastObjectStatus(namespace string, name string) prometheus.Gauge {
 	return lastObjectStatus.WithLabelValues(namespace, name)
 }
 
-func NewKluctlNumberOfChanges(namespace string, name string) prometheus.Gauge {
-	return numberOfChanges.WithLabelValues(namespace, name)
-}
-
-func NewKluctlNumberOfDeletedObjects(namespace string, name string) prometheus.Gauge {
-	return numberOfDeletedObjects.WithLabelValues(namespace, name)
-}
-
-func NewKluctlNumberOfErrors(namespace string, name string, action string) prometheus.Gauge {
-	return numberOfErrors.WithLabelValues(namespace, name, action)
-}
-
-func NewKluctlNumberOfImages(namespace string, name string) prometheus.Gauge {
-	return numberOfImages.WithLabelValues(namespace, name)
-}
-
-func NewKluctlNumberOfOrphanObjects(namespace string, name string) prometheus.Gauge {
-	return numberOfOrphanObjects.WithLabelValues(namespace, name)
-}
-
-func NewKluctlNumberOfWarnings(namespace string, name string, action string) prometheus.Gauge {
-	return numberOfWarnings.WithLabelValues(namespace, name, action)
-}
-
-func NewKluctlPruneDuration(namespace string, name string) prometheus.Observer {
-	return pruneDuration.WithLabelValues(namespace, name)
-}
-
 func NewKluctlPruneEnabled(namespace string, name string) prometheus.Gauge {
 	return pruneEnabled.WithLabelValues(namespace, name)
 }
 
 func NewKluctlSourceSpec(namespace string, name string, url string, path string, ref string) prometheus.Gauge {
 	return sourceSpec.WithLabelValues(namespace, name, url, path, ref)
-}
-
-func NewKluctlValidateDuration(namespace string, name string) prometheus.Observer {
-	return validateDuration.WithLabelValues(namespace, name)
 }


### PR DESCRIPTION
# Description

This PR adds basic metrics to the controller. When merged, the controller exports the following metrics:

- 	deployment_duration_seconds
- 	deployment_interval_seconds
- 	dry_run_enabled
- 	last_object_status
- 	number_of_changes
- 	number_of_deleted_objects
- 	number_of_errors
- 	number_of_images
- 	number_of_orphan_objects
- 	number_of_warnings
- 	prune_duration_seconds
- 	prune_enabled
- 	source_spec
- 	validate_duration_seconds

Fixes #86 
Fixes https://github.com/kluctl/www-kluctl.io/issues/58

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
